### PR TITLE
Improve price range slider selection

### DIFF
--- a/web-dashboard/src/components/CarAnalysisDashboard.jsx
+++ b/web-dashboard/src/components/CarAnalysisDashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useEffect, useMemo, useRef } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ScatterChart, Scatter, ResponsiveContainer, BarChart, Bar, PieChart, Pie, Cell } from 'recharts';
 import { Car, TrendingUp, BarChart3, MapPin, Filter, Upload, Download, RefreshCw, AlertCircle, CheckCircle, Calendar } from 'lucide-react';
 import Papa from 'papaparse';
@@ -547,6 +547,21 @@ export default function CarAnalysisDashboard() {
   const RangeSlider = ({ min, max, value, onChange, step = 1, unit = '' }) => {
     const [isDragging, setIsDragging] = useState(false);
     const [dragIndex, setDragIndex] = useState(null);
+    const sliderRef = useRef(null);
+
+    const handleTrackClick = (e) => {
+      const rect = sliderRef.current.getBoundingClientRect();
+      const clientX = e.clientX ?? (e.touches ? e.touches[0].clientX : 0);
+      let percent = (clientX - rect.left) / rect.width;
+      percent = Math.min(1, Math.max(0, percent));
+      const rawValue = min + percent * (max - min);
+      const newValue = Math.round(rawValue / step) * step;
+      const distToMin = Math.abs(newValue - value[0]);
+      const distToMax = Math.abs(newValue - value[1]);
+      const index = distToMin <= distToMax ? 0 : 1;
+      handleRangeChange(index, newValue);
+      setDragIndex(index);
+    };
     
     const handleRangeChange = (index, newValue) => {
       const numValue = parseInt(newValue);
@@ -567,7 +582,12 @@ export default function CarAnalysisDashboard() {
     const rightPercent = ((value[1] - min) / (max - min)) * 100;
 
     return (
-      <div style={{ position: 'relative', margin: '20px 0' }}>
+      <div
+        ref={sliderRef}
+        onMouseDown={handleTrackClick}
+        onTouchStart={handleTrackClick}
+        style={{ position: 'relative', margin: '20px 0' }}
+      >
         {/* トラック背景 */}
         <div style={{
           height: '8px',
@@ -615,7 +635,7 @@ export default function CarAnalysisDashboard() {
             appearance: 'none',
             cursor: 'pointer',
             zIndex: dragIndex === 0 ? 5 : 3,
-            pointerEvents: 'auto'
+            pointerEvents: 'none'
           }}
         />
         
@@ -646,7 +666,7 @@ export default function CarAnalysisDashboard() {
             appearance: 'none',
             cursor: 'pointer',
             zIndex: dragIndex === 1 ? 5 : 2,
-            pointerEvents: 'auto'
+            pointerEvents: 'none'
           }}
         />
         
@@ -2394,7 +2414,7 @@ export default function CarAnalysisDashboard() {
           appearance: none;
           background: transparent;
           cursor: pointer;
-          pointer-events: auto;
+          pointer-events: none;
         }
 
         input[type="range"]:focus {


### PR DESCRIPTION
## Summary
- allow clicking the track to move the nearest knob on the range slider

## Testing
- `pytest -q`
- `npm test -- --watchAll=false` *(fails: `react-scripts` permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_685245c242ac8321a8d67386e6e27bc1