### PR TITLE
Add fallback path for scraped data

### DIFF
--- a/scripts/export_for_web.py
+++ b/scripts/export_for_web.py
@@ -23,7 +23,8 @@ logger = logging.getLogger(__name__)
 def find_latest_data():
     """最新のRC Fデータファイルを検索"""
     project_root = Path(__file__).parent.parent
-    scraped_dir = project_root / 'data' / 'scraped' / 'F'
+    from src.utils import get_scraped_dir
+    scraped_dir = get_scraped_dir(project_root) / 'F'
     
     if not scraped_dir.exists():
         logger.error(f"データディレクトリが存在しません: {scraped_dir}")

--- a/scripts/gui_app.py
+++ b/scripts/gui_app.py
@@ -147,7 +147,11 @@ class CarAnalysisGUI:
         self.car_listbox.delete(0, tk.END)
         self.available_cars = {}
         
-        scraped_dir = project_root / 'data' / 'scraped'
+        # Determine scraped data directory. Prefer 'data/scraped' at the
+        # project root, but fall back to the bundled sample data under
+        # src/scraper if the directory doesn't exist.
+        from src.utils import get_scraped_dir
+        scraped_dir = get_scraped_dir(project_root)
         if not scraped_dir.exists():
             self.car_listbox.insert(tk.END, "スクレイピングデータがありません")
             return

--- a/scripts/gui_app_debug.py
+++ b/scripts/gui_app_debug.py
@@ -175,7 +175,8 @@ class CarAnalysisGUI:
             self.car_listbox.delete(0, tk.END)
             self.available_cars = {}
             
-            scraped_dir = project_root / 'data' / 'scraped'
+            from src.utils import get_scraped_dir
+            scraped_dir = get_scraped_dir(project_root)
             print(f"スクレイピングデータディレクトリ: {scraped_dir}")
             
             if not scraped_dir.exists():

--- a/scripts/gui_app_fixed.py
+++ b/scripts/gui_app_fixed.py
@@ -183,7 +183,11 @@ class CarAnalysisGUI:
         self.car_listbox.delete(0, tk.END)
         self.available_cars = {}
         
-        scraped_dir = project_root / 'data' / 'scraped'
+        # Prefer the runtime 'data/scraped' directory, but allow running
+        # against the example dataset under src/scraper when the default
+        # location does not exist.
+        from src.utils import get_scraped_dir
+        scraped_dir = get_scraped_dir(project_root)
         
         if not scraped_dir.exists():
             self.car_listbox.insert(tk.END, "❌ スクレイピングデータがありません")

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -101,7 +101,8 @@ class CarAnalysisSystem:
     
     def find_car_data_file(self, car_name, use_latest=True):
         """車種データファイル検索"""
-        scraped_dir = self.project_root / 'data' / 'scraped'
+        from src.utils import get_scraped_dir
+        scraped_dir = get_scraped_dir(self.project_root)
         car_dirs = list(scraped_dir.glob(f"*{car_name}*"))
         
         if not car_dirs:
@@ -147,7 +148,8 @@ class CarAnalysisSystem:
     
     def select_data_file_interactive(self):
         """インタラクティブファイル選択"""
-        scraped_dir = self.project_root / 'data' / 'scraped'
+        from src.utils import get_scraped_dir
+        scraped_dir = get_scraped_dir(self.project_root)
         
         if not scraped_dir.exists():
             print("スクレイピングデータが見つかりません")
@@ -268,7 +270,8 @@ class CarAnalysisSystem:
     
     def list_available_data(self):
         """利用可能データ一覧表示"""
-        scraped_dir = self.project_root / 'data' / 'scraped'
+        from src.utils import get_scraped_dir
+        scraped_dir = get_scraped_dir(self.project_root)
         
         if not scraped_dir.exists():
             print("スクレイピングデータが見つかりません")

--- a/src/utils/__init__.py
+++ b/src/utils/__init__.py
@@ -1,0 +1,1 @@
+from .paths import get_scraped_dir

--- a/src/utils/paths.py
+++ b/src/utils/paths.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+
+def get_scraped_dir(project_root: Path) -> Path:
+    """Return the directory containing scraped data.
+
+    If ``project_root/data/scraped`` exists, use it. Otherwise fall back to
+    ``project_root/src/scraper/data/scraped``.
+    """
+    default = project_root / 'data' / 'scraped'
+    if default.exists():
+        return default
+    return project_root / 'src' / 'scraper' / 'data' / 'scraped'

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -46,3 +46,16 @@ def test_car_scraper_output_dir(tmp_path):
     scraper = CarScraper(output_dir=tmp_path)
     assert scraper.output_dir == tmp_path
     assert scraper.output_dir.exists()
+
+from src.utils import get_scraped_dir
+
+
+def test_get_scraped_dir(tmp_path):
+    project_root = tmp_path
+    fallback = project_root / 'src' / 'scraper' / 'data' / 'scraped'
+    fallback.mkdir(parents=True)
+    assert get_scraped_dir(project_root) == fallback
+
+    default = project_root / 'data' / 'scraped'
+    default.mkdir(parents=True)
+    assert get_scraped_dir(project_root) == default


### PR DESCRIPTION
## Summary
- provide `get_scraped_dir` helper to resolve scraped data location
- use the helper in CLI tools and GUIs so both `data/scraped` and `src/scraper/data/scraped` work
- update export script accordingly
- test new helper logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68535238234483219aeb2dfad37f2a57