### PR TITLE
Add car directory scanning for dropdown

### DIFF
--- a/scripts/export_for_web.py
+++ b/scripts/export_for_web.py
@@ -10,6 +10,7 @@ import json
 import os
 import re
 from pathlib import Path
+import subprocess
 from datetime import datetime
 import logging
 
@@ -318,7 +319,10 @@ def main():
         logger.info("主要グレード分布:")
         for grade, count in grade_counts.items():
             logger.info(f"  {grade}: {count}件")
-        
+
+        # 車種・ファイルインデックス生成
+        subprocess.run(["python", str(Path(__file__).parent / "generate_car_file_index.py")], check=True)
+
         return True
         
     except Exception as e:

--- a/scripts/generate_car_file_index.py
+++ b/scripts/generate_car_file_index.py
@@ -1,0 +1,39 @@
+import json
+from pathlib import Path
+import shutil
+
+DATA_ROOT = Path(__file__).resolve().parent.parent / 'src' / 'scraper' / 'data' / 'scraped'
+OUTPUT_DIR = Path(__file__).resolve().parent.parent / 'web-dashboard' / 'public' / 'data'
+
+
+def collect_files():
+    index = {}
+    if not DATA_ROOT.exists():
+        return index
+    for car_dir in sorted([p for p in DATA_ROOT.iterdir() if p.is_dir()]):
+        car_name = car_dir.name
+        files = []
+        for date_dir in sorted(car_dir.glob('*')):
+            if not date_dir.is_dir():
+                continue
+            for csv in sorted(date_dir.glob('*.csv')):
+                rel_path = Path('scraped') / car_name / date_dir.name / csv.name
+                display = f"{date_dir.name} - {csv.name}"
+                files.append({"path": str(rel_path), "displayName": display})
+                dest = OUTPUT_DIR / rel_path
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copy(csv, dest)
+        if files:
+            index[car_name] = files
+    return index
+
+
+def main():
+    index = collect_files()
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    with open(OUTPUT_DIR / 'car_file_index.json', 'w', encoding='utf-8') as f:
+        json.dump(index, f, ensure_ascii=False, indent=2)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- generate `car_file_index.json` from scraped directories via new script
- copy CSV files into `public/data/scraped` and expose an index for the dashboard
- update dashboard to load car types and files from the generated index

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858b295f53883219638e9e423ad8527