### PR TITLE
Add CLI option for dashboard

### DIFF
--- a/command.txt
+++ b/command.txt
@@ -16,12 +16,6 @@ python scripts\main.py --all
 # 6. 利用可能データ一覧表示
 python scripts\main.py --list
 
-
-
-
-
-
-
 # 7. 特定車種の最新データを分析
 python scripts\main.py --analyze --car "GRヤリス" --latest
 
@@ -31,8 +25,6 @@ python scripts\main.py --analyze --path "data\scraped\GRヤリス\2025年06月17
 # 9. 特定車種（最新でない場合は選択画面）
 python scripts\main.py --analyze --car "レヴォーグ"
 
-
-
 # Step 1: まず利用可能なデータを確認
 python scripts\main.py --list
 
@@ -41,3 +33,6 @@ python scripts\main.py --scrape
 
 # Step 3: 分析実行
 python scripts\main.py --analyze --latest
+
+# 10. Reactダッシュボードをデータディレクトリ指定で起動
+cd web-dashboard && npm run start-dir --dir F

--- a/web-dashboard/package.json
+++ b/web-dashboard/package.json
@@ -18,7 +18,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "export-data": "python ../scripts/export_for_web.py",
-    "dev": "npm run export-data && npm start"
+    "dev": "npm run export-data && npm start",
+    "start-dir": "node start-dashboard.js --dir"
   },
   "eslintConfig": {
     "extends": [

--- a/web-dashboard/start-dashboard.js
+++ b/web-dashboard/start-dashboard.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const { spawn } = require('child_process');
+const path = require('path');
+
+const dirIndex = process.argv.indexOf('--dir');
+let carDir = '';
+if (dirIndex !== -1 && process.argv.length > dirIndex + 1) {
+  carDir = process.argv[dirIndex + 1];
+}
+
+const env = { ...process.env };
+if (carDir) {
+  env.REACT_APP_CAR_DIR = carDir;
+}
+
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const proc = spawn(npm, ['start'], { cwd: __dirname, stdio: 'inherit', env });
+proc.on('close', code => process.exit(code));


### PR DESCRIPTION
## Summary
- allow providing car directory via `REACT_APP_CAR_DIR`
- load all CSV files from a selected directory when exporting for the web
- add script `start-dashboard.js` for CLI startup
- hide dropdowns when a directory is provided
- document new command in `command.txt`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b78c067348321b7770df742a18075